### PR TITLE
Remove debugging console.log

### DIFF
--- a/src/packager.ts
+++ b/src/packager.ts
@@ -5,14 +5,12 @@ import PurgeCSS = require("purgecss")
 class PurgeCSSPackager extends CSSPackager {
   async addAsset(asset: CSSAsset) {
     if (this.options.minify) {
-      console.log("minify")
       const config = (await asset.parentBundle!.entryAsset.getConfig(
         ["purgecss.config.js"],
         { packageKey: "purgecss" }
       )) as PurgeCSS.Options
 
       if (config) {
-        console.log("config")
         asset.generated!.css = new PurgeCSS({
           ...config,
           css: [{ extension: "css", raw: asset.generated!.css }]


### PR DESCRIPTION
There are `console.log` statements in the processor, presumably for debugging, but it interrupts the parcel output. 

```
⠼ Packaging...minify
minify
minify
⠦ Packaging...config
config
config
```